### PR TITLE
Move PID file under /run

### DIFF
--- a/pkg/afancontrol.conf
+++ b/pkg/afancontrol.conf
@@ -1,6 +1,6 @@
 [daemon]
-# Default: /var/run/afancontrol.pid
-pidfile = /var/run/afancontrol.pid
+# Default: /run/afancontrol.pid
+pidfile = /run/afancontrol.pid
 
 # Default: (empty value)
 logfile = /var/log/afancontrol.log

--- a/pkg/afancontrol.service
+++ b/pkg/afancontrol.service
@@ -5,8 +5,8 @@ After=lm-sensors.service
 [Service]
 LimitNOFILE=8192
 ExecStartPre=/usr/bin/afancontrol daemon --test
-ExecStart=/usr/bin/afancontrol daemon --pidfile /var/run/afancontrol.pid
-PIDFile=/var/run/afancontrol.pid
+ExecStart=/usr/bin/afancontrol daemon --pidfile /run/afancontrol.pid
+PIDFile=/run/afancontrol.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/src/afancontrol/config.py
+++ b/src/afancontrol/config.py
@@ -30,7 +30,7 @@ from afancontrol.pwmfan import (
 from afancontrol.temp import CommandTemp, FileTemp, HDDTemp, Temp, TempCelsius
 
 DEFAULT_CONFIG = "/etc/afancontrol/afancontrol.conf"
-DEFAULT_PIDFILE = "/var/run/afancontrol.pid"
+DEFAULT_PIDFILE = "/run/afancontrol.pid"
 DEFAULT_INTERVAL = 5
 DEFAULT_FANS_SPEED_CHECK_INTERVAL = 3
 DEFAULT_HDDTEMP = "hddtemp"

--- a/tests/data/afancontrol-example.conf
+++ b/tests/data/afancontrol-example.conf
@@ -1,5 +1,5 @@
 [daemon]
-pidfile = /var/run/afancontrol.pid
+pidfile = /run/afancontrol.pid
 logfile = /var/log/afancontrol.log
 interval = 5
 exporter_listen_host = 127.0.0.1:8083

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,7 +59,7 @@ def test_pkg_conf(pkg_conf: Path):
     parsed = parse_config(pkg_conf, daemon_cli_config)
     assert parsed == ParsedConfig(
         daemon=DaemonConfig(
-            pidfile="/var/run/afancontrol.pid",
+            pidfile="/run/afancontrol.pid",
             logfile="/var/log/afancontrol.log",
             interval=5,
             exporter_listen_host=None,
@@ -118,7 +118,7 @@ def test_example_conf(example_conf: Path):
     parsed = parse_config(example_conf, daemon_cli_config)
     assert parsed == ParsedConfig(
         daemon=DaemonConfig(
-            pidfile="/var/run/afancontrol.pid",
+            pidfile="/run/afancontrol.pid",
             logfile="/var/log/afancontrol.log",
             exporter_listen_host="127.0.0.1:8083",
             interval=5,
@@ -238,7 +238,7 @@ temps = mobo
     parsed = parse_config(path_from_str(config), daemon_cli_config)
     assert parsed == ParsedConfig(
         daemon=DaemonConfig(
-            pidfile="/var/run/afancontrol.pid",
+            pidfile="/run/afancontrol.pid",
             logfile=None,
             exporter_listen_host=None,
             interval=5,


### PR DESCRIPTION
It fixes the following error:
```
/usr/lib/systemd/system/afancontrol.service:9: PIDFile= references a path below legacy directory /var/run/, updating /var/run/afancontrol.pid → /run/afancontrol.pid; please update the unit file accordingly.
```

`/run` is the standard path since FHS 3.0.