### PR TITLE
Support glob expansion with fans

### DIFF
--- a/src/afancontrol/configparser.py
+++ b/src/afancontrol/configparser.py
@@ -1,4 +1,5 @@
 import configparser
+import glob
 from typing import Any, Generic, Iterator, Optional, Type, TypeVar, Union, overload
 
 T = TypeVar("T", bound=str)
@@ -127,3 +128,12 @@ class ConfigParserSection(Generic[T]):
                 "[%s] %r option is expected to be set" % (self.__section.name, option)
             )
         return res
+
+
+def expand_glob(path: str):
+    matches = glob.glob(path)
+    if not matches:
+        return path  # a FileNotFoundError will be raised on a first read attempt
+    if len(matches) == 1:
+        return matches[0]
+    raise ValueError("Expected glob to expand to a single path, got %r" % (matches,))

--- a/src/afancontrol/pwmfan/linux.py
+++ b/src/afancontrol/pwmfan/linux.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import NewType
 
-from afancontrol.configparser import ConfigParserSection
+from afancontrol.configparser import ConfigParserSection, expand_glob
 from afancontrol.pwmfan.base import (
     BaseFanPWMRead,
     BaseFanPWMWrite,
@@ -18,7 +18,7 @@ class LinuxFanSpeed(BaseFanSpeed):
     __slots__ = ("_fan_input",)
 
     def __init__(self, fan_input: FanInputDevice) -> None:
-        self._fan_input = Path(fan_input)
+        self._fan_input = Path(expand_glob(fan_input))
 
     @classmethod
     def from_configparser(cls, section: ConfigParserSection) -> BaseFanSpeed:
@@ -35,7 +35,7 @@ class LinuxFanPWMRead(BaseFanPWMRead):
     min_pwm = PWMValue(0)
 
     def __init__(self, pwm: PWMDevice) -> None:
-        self._pwm = Path(pwm)
+        self._pwm = Path(expand_glob(pwm))
 
     @classmethod
     def from_configparser(cls, section: ConfigParserSection) -> BaseFanPWMRead:
@@ -51,8 +51,9 @@ class LinuxFanPWMWrite(BaseFanPWMWrite):
     read_cls = LinuxFanPWMRead
 
     def __init__(self, pwm: PWMDevice) -> None:
-        self._pwm = Path(pwm)
-        self._pwm_enable = Path(pwm + "_enable")
+        base = expand_glob(pwm)
+        self._pwm = Path(base)
+        self._pwm_enable = Path(base + "_enable")
 
     @classmethod
     def from_configparser(cls, section: ConfigParserSection) -> BaseFanPWMWrite:

--- a/src/afancontrol/temp/file.py
+++ b/src/afancontrol/temp/file.py
@@ -1,19 +1,10 @@
-import glob
 import re
 from pathlib import Path
 from typing import Optional, Tuple
 
-from afancontrol.configparser import ConfigParserSection
+from afancontrol.configparser import ConfigParserSection, expand_glob
 from afancontrol.temp.base import Temp, TempCelsius
 
-
-def _expand_glob(path: str):
-    matches = glob.glob(path)
-    if not matches:
-        return path  # a FileNotFoundError will be raised on a first read attempt
-    if len(matches) == 1:
-        return matches[0]
-    raise ValueError("Expected glob to expand to a single path, got %r" % (matches,))
 
 
 class FileTemp(Temp):
@@ -33,7 +24,7 @@ class FileTemp(Temp):
         #  /sys/devices/pci0000:00/0000:00:01.3/[...]/hwmon/hwmon*/temp1_input
         # The `hwmon*` might change after reboot, but it is always a single
         # directory within the device.
-        temp_path = _expand_glob(temp_path + "_input")
+        temp_path = expand_glob(temp_path + "_input")
         temp_path = re.sub(r"_input$", "", temp_path)
 
         self._temp_input = Path(temp_path + "_input")


### PR DESCRIPTION
Wildcard glob expansion is currently supported only on temperature sensors. `hwmon` ordering can change on a per-boot basis for PWM devices, as well.

Moved `expand_glob()` into the common `configparser.py` file and changed the PWM-related classes to use glob expansion.